### PR TITLE
[v1.4] Support to delete image files that are not in use

### DIFF
--- a/src/main/java/seedu/address/commons/util/DeleteUtil.java
+++ b/src/main/java/seedu/address/commons/util/DeleteUtil.java
@@ -1,0 +1,43 @@
+package seedu.address.commons.util;
+
+import java.io.File;
+import java.util.List;
+
+import javafx.collections.ObservableList;
+import seedu.address.model.person.Person;
+
+/**
+ * A class for deleting and managing unwanted storage files
+ */
+
+public class DeleteUtil {
+
+    /**
+     * Goes through the list of files to be deleted and only deletes those that are not in use
+     * @param itemsToDelete List of items (files) to delete
+     * @param persons List of Person objects in the addressbook
+     */
+    public static void clearImageFiles(List<String> itemsToDelete, ObservableList<Person> persons) {
+        for (String it : itemsToDelete) {
+            boolean notUsed = true;
+            for (Person p : persons) {
+                if (p.getDisplayPic().toString().equals(it)) {
+                    notUsed = false;
+                    break;
+                }
+            }
+            if (notUsed) {
+                deleteFile(it);
+            }
+        }
+    }
+
+    /**
+     * Delete a file at the given filepath.
+     * @param filepath where the file is located.
+     */
+    public static void deleteFile(String filepath) {
+        File toDelete = new File(filepath);
+        toDelete.delete();
+    }
+}

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -34,6 +34,9 @@ public class LogicManager extends ComponentManager implements Logic {
         clearRedundantImages();
     }
 
+    /**
+     * Clears the data folder of redundant images
+     */
     public void clearRedundantImages() {
         DeleteUtil.clearImageFiles(model.getItemList(), model.getFilteredPersonList());
         model.clearDeleteItems();

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -5,6 +5,7 @@ import java.util.logging.Logger;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.ComponentManager;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.util.DeleteUtil;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -30,6 +31,12 @@ public class LogicManager extends ComponentManager implements Logic {
         history = new CommandHistory();
         addressBookParser = new AddressBookParser();
         undoRedoStack = new UndoRedoStack();
+        clearRedundantImages();
+    }
+
+    public void clearRedundantImages() {
+        DeleteUtil.clearImageFiles(model.getItemList(), model.getFilteredPersonList());
+        model.clearDeleteItems();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DISPLAY_PIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MATRIC_NUMBER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -29,6 +30,7 @@ public class AddCommand extends UndoableCommand {
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
+            + PREFIX_DISPLAY_PIC + "[IMAGE TO DISPLAY PICTURE] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
@@ -36,6 +38,7 @@ public class AddCommand extends UndoableCommand {
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
+            + PREFIX_DISPLAY_PIC + "C:\\Users\\Hello\\Desktop\\picture.jpg "
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney";
 
@@ -60,6 +63,7 @@ public class AddCommand extends UndoableCommand {
             model.addPerson(toAdd);
             //Only save the display picture here
             toAdd.getDisplayPic().saveDisplay(toAdd.getDetails());
+            model.addDeleteItem(toAdd.getDisplayPic().toString());
             return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
         } catch (DuplicatePersonException e) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import java.io.File;
 import java.util.List;
 import java.util.Objects;
 
@@ -45,10 +44,7 @@ public class DeleteCommand extends UndoableCommand {
         } catch (PersonNotFoundException pnfe) {
             throw new AssertionError("The target person cannot be missing");
         }
-        if (!personToDelete.getDisplayPic().isDefault()) {
-            File toDelete = new File(personToDelete.getDisplayPic().toString());
-            toDelete.deleteOnExit();
-        }
+        model.addDeleteItem(personToDelete.getDisplayPic().toString());
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -87,6 +87,12 @@ public class EditCommand extends UndoableCommand {
         } catch (PersonNotFoundException pnfe) {
             throw new AssertionError("The target person cannot be missing");
         }
+        if (!personToEdit.getDisplayPic().equals(editedPerson.getDisplayPic())) {
+            if (!personToEdit.getDisplayPic().isDefault()) {
+                model.addDeleteItem(personToEdit.getDisplayPic().toString());
+                model.addDeleteItem(editedPerson.getDisplayPic().toString());
+            }
+        }
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
     }
@@ -117,18 +123,16 @@ public class EditCommand extends UndoableCommand {
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
         DisplayPic updatedDisplay = editPersonDescriptor.getDisplayPic().orElse(personToEdit.getDisplayPic());
-        try {
-            if (personToEdit.getDisplayPic().isDefault()) {
+        if (!updatedDisplay.equals(personToEdit.getDisplayPic())) {
+            try {
                 updatedDisplay.saveDisplay(updatedName.toString() + updatedPhone.toString()
                         + updatedEmail.toString());
                 updatedDisplay.updateDisplay(updatedName.toString() + updatedPhone.toString()
                         + updatedEmail.toString());
-            } else {
-                updatedDisplay.saveDisplay(personToEdit.getDisplayPic().toString());
-                updatedDisplay.updateDisplay(personToEdit.getDisplayPic().toString());
+
+            } catch (IllegalValueException ive) {
+                updatedDisplay.updateToDefault();
             }
-        } catch (IllegalValueException ive) {
-            updatedDisplay.updateToDefault();
         }
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import javafx.collections.ObservableList;
+import seedu.address.model.item.UniqueItemList;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
@@ -29,6 +30,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     private final UniqueTaskList tasks;
     private final UniquePersonList persons;
     private final UniqueTagList tags;
+    private final UniqueItemList itemList;
 
     /*
      * The 'unusual' code block below is an non-static initialization block, sometimes used to avoid duplication
@@ -41,6 +43,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         tasks = new UniqueTaskList();
         persons = new UniquePersonList();
         tags = new UniqueTagList();
+        itemList = new UniqueItemList();
     }
 
     public AddressBook() {}
@@ -57,6 +60,10 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     public void setPersons(List<Person> persons) throws DuplicatePersonException {
         this.persons.setPersons(persons);
+    }
+
+    public void setItemList(List<String> itemList) {
+        this.itemList.setItemList(itemList);
     }
 
     public void setTasks(List<Task> tasks) {
@@ -80,6 +87,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         try {
             setPersons(syncedPersonList);
             setTasks(newData.getTaskList());
+            setItemList(newData.getItemList());
         } catch (DuplicatePersonException e) {
             throw new AssertionError("AddressBooks should not have duplicate persons");
         }
@@ -132,6 +140,20 @@ public class AddressBook implements ReadOnlyAddressBook {
         // This can cause the tags master list to have additional tags that are not tagged to any person
         // in the task list.
         tasks.add(t);
+    }
+
+    /**
+     * Adds an item to be scheduled to be deleted to the address book.
+     */
+    public void addDeleteItem(String filepath) {
+        itemList.add(filepath);
+    }
+
+    /**
+     * Removes all items to be scheduled to be deleted to the address book.
+     */
+    public void clearItems() {
+        itemList.clear();
     }
 
     /**
@@ -196,6 +218,11 @@ public class AddressBook implements ReadOnlyAddressBook {
     @Override
     public ObservableList<Tag> getTagList() {
         return tags.asObservableList();
+    }
+
+    @Override
+    public List<String> getItemList() {
+        return itemList.getItemList();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -2,6 +2,7 @@ package seedu.address.model;
 
 import java.time.YearMonth;
 
+import java.util.List;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -38,6 +39,12 @@ public interface Model {
     /** Adds the given task */
     void addTask(Task task);
 
+    /** Adds an item to be deleted */
+    void addDeleteItem(String filepath);
+
+    /** Clears the list of items to be deleted */
+    void clearDeleteItems();
+
     /**
      * Replaces the given person {@code target} with {@code editedPerson}.
      *
@@ -53,6 +60,9 @@ public interface Model {
 
     /** Returns an unmodifiable view of the filtered task list */
     ObservableList<Task> getFilteredTaskList();
+
+    /** Returns an unmodifiable view of the filtered items list */
+    List<String> getItemList();
 
     /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -3,6 +3,9 @@ package seedu.address.model;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -27,6 +30,7 @@ public class ModelManager extends ComponentManager implements Model {
     private final AddressBook addressBook;
     private final FilteredList<Person> filteredPersons;
     private final FilteredList<Task> filteredTasks;
+    private final ArrayList<String> filteredDeleteItems;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -40,6 +44,7 @@ public class ModelManager extends ComponentManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
         filteredTasks = new FilteredList<>(this.addressBook.getTaskList());
+        filteredDeleteItems = new ArrayList<>(this.addressBook.getItemList());
     }
 
     public ModelManager() {
@@ -80,6 +85,18 @@ public class ModelManager extends ComponentManager implements Model {
     public synchronized void addTask(Task task) {
         addressBook.addTask(task);
         updateFilteredTaskList(PREDICATE_SHOW_ALL_CURRENT_TASKS);
+        indicateAddressBookChanged();
+    }
+
+    @Override
+    public synchronized void addDeleteItem(String filepath) {
+        addressBook.addDeleteItem(filepath);
+        indicateAddressBookChanged();
+    }
+
+    @Override
+    public synchronized void clearDeleteItems() {
+        addressBook.clearItems();
         indicateAddressBookChanged();
     }
 
@@ -125,6 +142,12 @@ public class ModelManager extends ComponentManager implements Model {
         requireNonNull(predicate);
         filteredTasks.setPredicate(predicate);
     }
+
+    //=========== Item List Accessors ======================================================================
+    public List<String> getItemList() {
+        return Collections.unmodifiableList(filteredDeleteItems);
+    }
+
 
 
     @Override

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -1,5 +1,7 @@
 package seedu.address.model;
 
+import java.util.List;
+
 import javafx.collections.ObservableList;
 import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;
@@ -26,5 +28,10 @@ public interface ReadOnlyAddressBook {
      * This list will not contain any duplicate tags.
      */
     ObservableList<Tag> getTagList();
+
+    /**
+     * Returns an unmodifiable list of filepaths which are strings.
+     */
+    List<String> getItemList();
 
 }

--- a/src/main/java/seedu/address/model/item/UniqueItemList.java
+++ b/src/main/java/seedu/address/model/item/UniqueItemList.java
@@ -1,0 +1,72 @@
+package seedu.address.model.item;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A list of filepaths that enforces uniqueness between its elements and does not allow nulls.
+ *
+ * Supports a minimal set of list operations.
+ *
+ * @see String#equals(Object)
+ */
+public class UniqueItemList {
+
+    private final ArrayList<String> internalList = new ArrayList<>();
+
+    /**
+     * Returns true if the list contains an equivalent item/filepath as the given argument.
+     */
+    public boolean contains(String toCheck) {
+        requireNonNull(toCheck);
+        return internalList.contains(toCheck);
+    }
+
+    /**
+     * Adds a filepath to the list.
+     *
+     */
+    public void add(String toAdd) {
+        requireNonNull(toAdd);
+        internalList.add(toAdd);
+    }
+
+    /**
+     * Removes the equivalent item/filepath from the list.
+     *
+     */
+    public void remove(String toRemove) {
+        requireNonNull(toRemove);
+        internalList.remove(toRemove);
+    }
+
+    public void setItemList(List<String> replacement) {
+        requireNonNull(replacement);
+        this.internalList.clear();
+        this.internalList.addAll(replacement);
+    }
+
+    public void clear() {
+        this.internalList.clear();
+    }
+
+    public List<String> getItemList() {
+        return Collections.unmodifiableList(internalList);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof UniqueItemList // instanceof handles nulls
+                && this.internalList.equals(((UniqueItemList) other).internalList));
+    }
+
+    @Override
+    public int hashCode() {
+        return internalList.hashCode();
+    }
+}
+

--- a/src/main/java/seedu/address/model/person/DisplayPic.java
+++ b/src/main/java/seedu/address/model/person/DisplayPic.java
@@ -53,13 +53,13 @@ public class DisplayPic {
     /**
      * Saves the display picture to the specified storage location.
      */
-    public boolean saveDisplay(String personDetails) throws IllegalValueException {
+    public void saveDisplay(String personDetails) throws IllegalValueException {
         if (originalPath.equals(value)) {
-            return true;
+            return;
         }
         String fileType = FileUtil.getFileType(originalPath);
-        String uniqueFileName = NamingUtil.generateUniqueName(personDetails);
-        return DisplayPicStorage.saveDisplayPic(uniqueFileName, originalPath, fileType);
+        String uniqueFileName = DisplayPicStorage.saveDisplayPic(personDetails, originalPath, fileType);
+        this.value = DEFAULT_IMAGE_LOCATION + uniqueFileName + '.' + fileType;
     }
 
     public void updateToDefault() {
@@ -71,17 +71,14 @@ public class DisplayPic {
      * @param personDetails are the details to hash to ensure a unique value
      */
     public void updateDisplay(String personDetails) {
-        if (!this.value.equals(DEFAULT_DISPLAY_PIC)) {
-            String uniqueFileName = NamingUtil.generateUniqueName(personDetails);
-            try {
-                String fileType = FileUtil.getFileType(value);
-                DisplayPicStorage.saveDisplayPic(uniqueFileName, value, fileType);
-                //mark for delete the old photo(value) here
-                this.value = DEFAULT_IMAGE_LOCATION + uniqueFileName + '.' + fileType;
-            } catch (IllegalValueException ive) {
-                assert false;
-            }
+        try {
+            String fileType = FileUtil.getFileType(value);
+            String uniqueFileName = DisplayPicStorage.saveDisplayPic(personDetails, value, fileType);
+            this.value = DEFAULT_IMAGE_LOCATION + uniqueFileName + '.' + fileType;
+        } catch (IllegalValueException ive) {
+            assert false;
         }
+
     }
 
     public boolean isDefault() {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -91,7 +91,8 @@ public class Person {
                 && otherPerson.getMatricNumber().equals(this.getMatricNumber())
                 && otherPerson.getPhone().equals(this.getPhone())
                 && otherPerson.getEmail().equals(this.getEmail())
-                && otherPerson.getAddress().equals(this.getAddress());
+                && otherPerson.getAddress().equals(this.getAddress())
+                && otherPerson.getDisplayPic().equals(this.getDisplayPic());
     }
 
     @Override

--- a/src/main/java/seedu/address/storage/DisplayPicStorage.java
+++ b/src/main/java/seedu/address/storage/DisplayPicStorage.java
@@ -76,10 +76,10 @@ public class DisplayPicStorage {
             File input = new File(filePath);
             BufferedImage image = ImageIO.read(input);
             String uniqueFileName = NamingUtil.generateUniqueName(name);
-            File toSave = new File(DisplayPic.DEFAULT_IMAGE_LOCATION + uniqueFileName);
+            File toSave = new File(DisplayPic.DEFAULT_IMAGE_LOCATION + uniqueFileName + '.' + fileType);
             while (FileUtil.isFileExists(toSave)) {
                 uniqueFileName = NamingUtil.generateUniqueName(uniqueFileName);
-                toSave = new File(DisplayPic.DEFAULT_IMAGE_LOCATION + uniqueFileName);
+                toSave = new File(DisplayPic.DEFAULT_IMAGE_LOCATION + uniqueFileName + '.' + fileType);
             }
             FileUtil.copyImage(image, fileType, SAVE_LOCATION + uniqueFileName + '.' + fileType);
             return uniqueFileName;

--- a/src/main/java/seedu/address/storage/DisplayPicStorage.java
+++ b/src/main/java/seedu/address/storage/DisplayPicStorage.java
@@ -13,6 +13,7 @@ import seedu.address.MainApp;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.AppUtil;
 import seedu.address.commons.util.FileUtil;
+import seedu.address.commons.util.NamingUtil;
 import seedu.address.model.person.DisplayPic;
 
 /**
@@ -68,16 +69,22 @@ public class DisplayPicStorage {
      * @param name the name of the new image file
      * @param filePath the location of the current image file
      * @param fileType the file extension of the current image file
-     * @return whether the image was successfully copied
+     * @return the filename of the image
      */
-    public static boolean saveDisplayPic(String name, String filePath, String fileType) {
+    public static String saveDisplayPic(String name, String filePath, String fileType) throws IllegalValueException {
         try {
             File input = new File(filePath);
             BufferedImage image = ImageIO.read(input);
-            FileUtil.copyImage(image, fileType, SAVE_LOCATION + name + '.' + fileType);
-            return true;
+            String uniqueFileName = NamingUtil.generateUniqueName(name);
+            File toSave = new File(DisplayPic.DEFAULT_IMAGE_LOCATION + uniqueFileName);
+            while (FileUtil.isFileExists(toSave)) {
+                uniqueFileName = NamingUtil.generateUniqueName(uniqueFileName);
+                toSave = new File(DisplayPic.DEFAULT_IMAGE_LOCATION + uniqueFileName);
+            }
+            FileUtil.copyImage(image, fileType, SAVE_LOCATION + uniqueFileName + '.' + fileType);
+            return uniqueFileName;
         } catch (IOException | IllegalValueException exc) {
-            return false;
+            throw new IllegalValueException("Unable to write file");
         }
     }
 

--- a/src/main/java/seedu/address/storage/XmlAdaptedItem.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedItem.java
@@ -1,0 +1,59 @@
+package seedu.address.storage;
+
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlElement;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+
+/**
+ * JAXB-friendly version of a filepath.
+ */
+public class XmlAdaptedItem {
+
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Filepath is missing.";
+
+    @XmlElement(required = true)
+    private String filepath;
+
+    /**
+     * Constructs an XmlAdaptedItem.
+     * This is the no-arg constructor that is required by JAXB.
+     */
+    public XmlAdaptedItem() {}
+
+    /**
+     * Constructs an {@code XmlAdaptedItem} with the given item details.
+     */
+    public XmlAdaptedItem(String filepath) {
+        this.filepath = filepath;
+    }
+
+    /**
+     * Converts this jaxb-friendly adapted Item object into a string
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted item
+     */
+    public String toModelType() throws IllegalValueException {
+
+        if (this.filepath == null) {
+            throw new IllegalValueException(MISSING_FIELD_MESSAGE_FORMAT);
+        }
+
+        return filepath;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof XmlAdaptedItem)) {
+            return false;
+        }
+
+        XmlAdaptedItem otherTask = (XmlAdaptedItem) other;
+        return Objects.equals(filepath, otherTask.filepath);
+    }
+}

--- a/src/main/java/seedu/address/storage/XmlSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/XmlSerializableAddressBook.java
@@ -28,6 +28,8 @@ public class XmlSerializableAddressBook implements ReadOnlyAddressBook {
     private List<XmlAdaptedTask> tasks;
     @XmlElement
     private List<XmlAdaptedTag> tags;
+    @XmlElement
+    private List<XmlAdaptedItem> items;
 
     /**
      * Creates an empty XmlSerializableAddressBook.
@@ -37,6 +39,7 @@ public class XmlSerializableAddressBook implements ReadOnlyAddressBook {
         persons = new ArrayList<>();
         tags = new ArrayList<>();
         tasks = new ArrayList<>();
+        items = new ArrayList<>();
     }
 
     /**
@@ -47,6 +50,7 @@ public class XmlSerializableAddressBook implements ReadOnlyAddressBook {
         persons.addAll(src.getPersonList().stream().map(XmlAdaptedPerson::new).collect(Collectors.toList()));
         tasks.addAll(src.getTaskList().stream().map(XmlAdaptedTask::new).collect(Collectors.toList()));
         tags.addAll(src.getTagList().stream().map(XmlAdaptedTag::new).collect(Collectors.toList()));
+        items.addAll(src.getItemList().stream().map(XmlAdaptedItem::new).collect(Collectors.toList()));
     }
 
     /**
@@ -65,6 +69,9 @@ public class XmlSerializableAddressBook implements ReadOnlyAddressBook {
         }
         for (XmlAdaptedTask ta : tasks) {
             addressBook.addTask(ta.toModelType());
+        }
+        for (XmlAdaptedItem it : items) {
+            addressBook.addDeleteItem(it.toModelType());
         }
         return addressBook;
     }
@@ -117,5 +124,17 @@ public class XmlSerializableAddressBook implements ReadOnlyAddressBook {
             }
         }).collect(Collectors.toCollection(FXCollections::observableArrayList));
         return FXCollections.unmodifiableObservableList(tags);
+    }
+
+    @Override
+    public ObservableList<String> getItemList() {
+        final ObservableList<String> items = this.items.stream().map(it -> {
+            try {
+                return it.toModelType();
+            } catch (IllegalValueException e) {
+                return null;
+            }
+        }).collect(Collectors.toCollection(FXCollections::observableArrayList));
+        return FXCollections.unmodifiableObservableList(items);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.Predicate;
 
 import org.junit.Rule;
@@ -146,6 +147,20 @@ public class AddCommandTest {
 
         @Override
         public void updateFilteredTaskList(Predicate<Task> predicate) {
+
+        }
+
+        @Override
+        public void addDeleteItem(String filepath) {
+        }
+
+        @Override
+        public List<String> getItemList() {
+            return null;
+        }
+
+        @Override
+        public void clearDeleteItems() {
 
         }
     }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -95,6 +95,11 @@ public class AddressBookTest {
         public ObservableList<Tag> getTagList() {
             return tags;
         }
+
+        @Override
+        public List<String> getItemList() {
+            return null;
+        }
     }
 
 }


### PR DESCRIPTION
Upon starting the application, it will scan through the list of image files that are in use and delete those that have been marked as garbage.

Unsupported:
Currently does not have support for "Clear" command. Display Picture files will not be deleted if you use the clear command.